### PR TITLE
Tap 'homebrew/science' is deprecated. This commit replaces it with tap

### DIFF
--- a/install_Ipopt_CppAD.md
+++ b/install_Ipopt_CppAD.md
@@ -13,7 +13,7 @@ At this point in the curriculum students will have set up their SDC Term 2 envir
 * [Ipopt](https://projects.coin-or.org/Ipopt)
   * **Mac:**
     ```
-      brew tap homebrew/science
+      brew tap dpo/openblas
       brew install ipopt --with-openblas
     ```
 


### PR DESCRIPTION
'dpo/openblas'.