### PR TITLE
added sudo before make install - install_ipopt.sh

### DIFF
--- a/install_ipopt.sh
+++ b/install_ipopt.sh
@@ -17,7 +17,7 @@ cd $srcdir/ThirdParty/Blas
 ./get.Blas
 mkdir -p build && cd build
 ../configure --prefix=$prefix --disable-shared --with-pic
-make install
+sudo make install
 
 # Lapack
 cd $srcdir/ThirdParty/Lapack
@@ -25,7 +25,7 @@ cd $srcdir/ThirdParty/Lapack
 mkdir -p build && cd build
 ../configure --prefix=$prefix --disable-shared --with-pic \
     --with-blas="$prefix/lib/libcoinblas.a -lgfortran"
-make install
+sudo make install
 
 # ASL
 cd $srcdir//ThirdParty/ASL
@@ -42,4 +42,4 @@ cd $srcdir
     --with-lapack=$prefix/lib/libcoinlapack.a
 make
 make test
-make -j1 install
+sudo make -j1 install


### PR DESCRIPTION
Fixes the error due to lack of administrative privileges when installing  Blas, Lapack, and other packages -

sample error message occurred when installing Blas package (where installation fails as libcoinblas.la file was not created due to lack of permission):

`creating libcoinblas.la
(cd .libs && rm -f libcoinblas.la && ln -s ../libcoinblas.la libcoinblas.la)
make[1]: Entering directory '/mnt/e/Self-Driving-Car/Term2/CarND-MPC-Quizzes/Ipopt-3.12.7/ThirdParty/Blas/build'
test -z "/usr/local/lib" || mkdir -p -- "/usr/local/lib"
/bin/bash ./libtool --mode=install /usr/bin/install -c  'libcoinblas.la' '/usr/local/lib/libcoinblas.la'
/usr/bin/install -c .libs/libcoinblas.lai /usr/local/lib/libcoinblas.la
/usr/bin/install: cannot create regular file '/usr/local/lib/libcoinblas.la': Permission denied
Makefile:381: recipe for target 'install-libLTLIBRARIES' failed
make[1]: *** [install-libLTLIBRARIES] Error 1
make[1]: Leaving directory '/mnt/e/Self-Driving-Car/Term2/CarND-MPC-Quizzes/Ipopt-3.12.7/ThirdParty/Blas/build'
Makefile:640: recipe for target 'install-am' failed
make: *** [install-am] Error 2`