### PR TITLE
CMakeLists.txt typo

### DIFF
--- a/global_kinematic_model/CMakeLists.txt
+++ b/global_kinematic_model/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.5)
 add_definitions(-std=c++11)
 
 set(CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS}")
 
 set(sources src/main.cpp)
 

--- a/mpc_to_line/CMakeLists.txt
+++ b/mpc_to_line/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.5)
 add_definitions(-std=c++11)
 
 set(CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS}")
 
 set(sources src/MPC.cpp)
 

--- a/polyfit/CMakeLists.txt
+++ b/polyfit/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.5)
 add_definitions(-std=c++11)
 
 set(CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS}")
 
 set(sources src/main.cpp)
 


### PR DESCRIPTION
Removes comma in set(CMAKE_CXX_FLAGS "${CXX_FLAGS}") that was stopping the compilation flags from working.