### PR TITLE
BugFix for Ubuntu 18.04.1 LTS

### DIFF
--- a/install-ubuntu-MPC.sh
+++ b/install-ubuntu-MPC.sh
@@ -10,8 +10,8 @@ sudo apt-get install gfortran
 sudo apt-get install unzip
 
 # Ipopt: get, install, unzip
-wget https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.7.zip && unzip Ipopt-3.12.7.zip && rm Ipopt-3.12.7.zip
-./install_ipopt.sh
+wget https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.11.zip && unzip Ipopt-3.12.11.zip && rm Ipopt-3.12.11.zip
+./install_ipopt.sh ./Ipopt-3.12.11
 
 # CppAD
 sudo apt-get install cppad


### PR DESCRIPTION
I'm running on Ubuntu 18.04.1 LTS

I installed both scripts: ```./install-ubuntu-MPC``` and ```./install_ipopt.sh Ipopt-3.12.7```

Even if I copied the solution/MPC.cpp file to the src folder I always got the error:

```
cppad-20180000.0 error from a known source:
vector: index greater than or equal vector size
Error detected by false result for
    i < length_
at line 476 in the file 
    /usr/include/cppad/utility/vector.hpp
mpc: /usr/include/cppad/utility/error_handler.hpp:206: static void CppAD::ErrorHandler::Default(bool, int, const char*, const char*, const char*): Assertion `false' failed.
./run.sh: line 9:  2822 Aborted                 (core dumped) ./mpc
```

I was able to resolve this error by upgrading to the latest Ipopt version 3.12.11.

Finally I updated the install script ```./install-ubuntu-MPC```